### PR TITLE
Updated README to indicate enabling bot settings to allow groups. The…

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,12 @@ Install all required dependencies via: `pip install -r requirements.txt`
 ## [Create Telegram bot token via BotFather](#create-telegram-bot-token-via-botfather)
 Start a Telegram chat with [BotFather](https://t.me/BotFather) and click `start`.
 
-Then send `/newbot` in the chat, and follow the given steps to create a new telegram token. Save this token, you will need it in a second.
+Then send `/newbot` in the chat, and follow the given steps to create a new telegram token. 
+Save this token, you will need it in a second.
+
+Please note that you can specify various Bot Settings for your Bot.
+If you'd like to add your bot to a group chat, make sure that "allow groups?" is enabled in your bot
+settings (it should be enabled by default).
 
 ## [Set environment variables](#set-environment-variables)
 Set the telegram bot token you just created as an environment variable: `TELEGRAM_BOT_TOKEN`


### PR DESCRIPTION
… issue of not being able to add the bot to a group occured to one node operator and should therefore be included in the README.

## Description
Updated README to indicate enabling bot settings to allow groups.
One node operator wasn't able to add his bot to a group.
The issue was that he had "allow groups?" for his bot disabled.

## Fixes (issue)

Did you fix something? Leave empty if this PR contains just the new feature.


## Improvements

README indicate bot settings "allow groups?"

## How Has This Been Tested?
Read the README

## Checklist:
If you have any comments regarding one of these points just write it down.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
