### PR TITLE
bump major telegram bot library version

### DIFF
--- a/bot/handlers/handlers.py
+++ b/bot/handlers/handlers.py
@@ -9,7 +9,6 @@ from handlers.thornodes_handlers import *
 from jobs.jobs import start_user_job
 
 
-@run_async
 def on_start_command(update, context):
     """
     Send start message and display action buttons.
@@ -46,7 +45,6 @@ def on_start_command(update, context):
                                text=text)
 
 
-@run_async
 def dispatch_query(update, context):
     """
     Call right function depending on the button clicked
@@ -123,7 +121,6 @@ def dispatch_query(update, context):
         return asyncio.run(call(update, context))
 
 
-@run_async
 def dispatch_plain_input_query(update, context):
     """
     Handle if the users sends a message
@@ -151,7 +148,6 @@ def dispatch_plain_input_query(update, context):
         return handle_change_threshold(update, context)
 
 
-@run_async
 def on_my_nodes_clicked(update, context):
     keyboard = [[
         InlineKeyboardButton('🦸 THORCHAIN NODES',
@@ -182,4 +178,4 @@ def error_handler(update, context):
     Log error.
     """
 
-    logger.warning('Update "%s" caused error: %s', update, context.error)
+    logger.error(f'There is an unhandler error!\n {context.error} ')

--- a/bot/handlers/handlers.py
+++ b/bot/handlers/handlers.py
@@ -178,4 +178,4 @@ def error_handler(update, context):
     Log error.
     """
 
-    logger.error(f'There is an unhandler error!\n {context.error} ')
+    logger.error(f'There is an undhandled error!\n {context.error} ')

--- a/bot/handlers/other_nodes_handlers.py
+++ b/bot/handlers/other_nodes_handlers.py
@@ -21,10 +21,10 @@ def show_other_nodes_menu(update, context):
     keyboard = build_2_columns_keyboard(buttons)
     keyboard.append([InlineKeyboardButton('⬅ BACK', callback_data='my_nodes_menu-edit')])
 
-    update.callback_query.edit_message_text(context=context,
-                                            text=text,
-                                            parse_mode='markdown',
-                                            reply_markup=InlineKeyboardMarkup(keyboard))
+    update.callback_query.edit_message_text(
+        text=text,
+        parse_mode='markdown',
+        reply_markup=InlineKeyboardMarkup(keyboard))
 
 
 def show_other_nodes_details(update, context):
@@ -66,8 +66,7 @@ def show_other_nodes_details(update, context):
     else:
         text += f"*currently unavailable*"
 
-    query.edit_message_text(context=context,
-                            text=text,
+    query.edit_message_text(text=text,
                             parse_mode='markdown',
                             reply_markup=InlineKeyboardMarkup(
                                 [[InlineKeyboardButton('⬅️ BACK', callback_data='show_nodes_other')]]))

--- a/bot/handlers/thornodes_handlers.py
+++ b/bot/handlers/thornodes_handlers.py
@@ -9,7 +9,6 @@ from service.utils import *
 from datetime import timedelta
 
 
-@run_async
 def confirm_add_all_thornodes(update, _):
     """
     Ask user if he really wants to add all available Thornodes
@@ -24,7 +23,6 @@ def confirm_add_all_thornodes(update, _):
     return show_confirmation_menu(update=update, text=text, keyboard=keyboard)
 
 
-@run_async
 def confirm_delete_all_thornodes(update, context):
     """
     Ask user if he really wants to delete all available Thornodes
@@ -39,7 +37,6 @@ def confirm_delete_all_thornodes(update, context):
     return show_confirmation_menu(update=update, text=text, keyboard=keyboard)
 
 
-@run_async
 def add_thornode(update, context):
     """
     Initiate a conversation and prompt for user input (thornode address).
@@ -51,7 +48,6 @@ def add_thornode(update, context):
     return show_text_input_message(update, text)
 
 
-@run_async
 def change_alias(update, context):
     """
     Initiate a conversation and prompt for user input (new alias).
@@ -270,8 +266,7 @@ def show_my_thorchain_nodes_menu(update, context):
         text = 'You do not monitor any THORNodes yet.\nAdd a Node!'
 
     if len(keyboard) < KEYBOARD_PAGE_SIZE:
-        update.callback_query.edit_message_text(context=context,
-                                                text=text,
+        update.callback_query.edit_message_text(text=text,
                                                 parse_mode='markdown',
                                                 reply_markup=InlineKeyboardMarkup(keyboard))
     else:
@@ -279,10 +274,10 @@ def show_my_thorchain_nodes_menu(update, context):
         for i in range(pages):
             try_message(context=context,
                         chat_id=update.effective_message.chat_id,
-                        text=f"{text}\n(Page {i+1} of {pages})",
-                        reply_markup=InlineKeyboardMarkup(keyboard[(i * KEYBOARD_PAGE_SIZE): ((i + 1) * KEYBOARD_PAGE_SIZE)]))
+                        text=f"{text}\n(Page {i + 1} of {pages})",
+                        reply_markup=InlineKeyboardMarkup(
+                            keyboard[(i * KEYBOARD_PAGE_SIZE): ((i + 1) * KEYBOARD_PAGE_SIZE)]))
             text = "Click an address from the list below or add a node:"
-
 
 
 def get_thornode_menu_buttons(chat_data):

--- a/bot/jobs/jobs.py
+++ b/bot/jobs/jobs.py
@@ -3,7 +3,7 @@ from jobs.thorchain_network_jobs import check_network_security_job, check_thorch
 from jobs.thorchain_node_jobs import *
 
 
-def setup_bot_data(dispatcher):
+def setup_bot_jobs(dispatcher):
     dispatcher.job_queue.run_repeating(general_bot_checks,
                                        interval=JOB_INTERVAL_IN_SECONDS)
     dispatcher.job_queue.run_repeating(check_bitcoin_height_increase_job,

--- a/bot/service/setup.py
+++ b/bot/service/setup.py
@@ -111,5 +111,4 @@ def setup_debug_processes():
         increase_block_height_process.terminate()
 
     atexit.register(cleanup)
-    time.sleep(
-        1)  # Make sure all processes started before bot starts using them
+    time.sleep(1)  # Make sure all processes started before bot starts using them

--- a/bot/thornode_bot.py
+++ b/bot/thornode_bot.py
@@ -33,18 +33,17 @@ def main():
         raise
 
     bot = Updater(bot=mq_bot,
-                  persistence=PicklePersistence(filename=session_data_path),
-                  use_context=True)
+                  persistence=PicklePersistence(filename=session_data_path))
 
     dispatcher = bot.dispatcher
 
     setup_existing_users(dispatcher=dispatcher)
-    setup_bot_data(dispatcher=dispatcher)
+    setup_bot_jobs(dispatcher=dispatcher)
 
-    dispatcher.add_handler(CommandHandler('start', on_start_command))
-    dispatcher.add_handler(CallbackQueryHandler(dispatch_query))
-    dispatcher.add_handler(MessageHandler(Filters.text, dispatch_plain_input_query))
-    dispatcher.add_error_handler(error_handler)
+    dispatcher.add_handler(CommandHandler('start', on_start_command, run_async=True))
+    dispatcher.add_handler(CallbackQueryHandler(dispatch_query, run_async=True))
+    dispatcher.add_handler(MessageHandler(Filters.text, dispatch_plain_input_query, run_async=True))
+    dispatcher.add_error_handler(error_handler, run_async=True)
 
     # Start the bot
     bot.start_polling()

--- a/bot/thornode_bot.py
+++ b/bot/thornode_bot.py
@@ -32,8 +32,8 @@ def main():
                      " correct Telegram bot token. Check project docs for more details.", exc_info=True)
         raise
 
-    bot = Updater(bot=mq_bot,
-                  persistence=PicklePersistence(filename=session_data_path))
+    bot = Updater(bot=mq_bot, persistence=PicklePersistence(filename=session_data_path, store_bot_data=False),
+                  workers=8)
 
     dispatcher = bot.dispatcher
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pyrogram==0.16.0
 requests==2.23.0
-python-telegram-bot==12.6.1
+python-telegram-bot==13.2
 tgcrypto==1.2.0
 aiohttp==3.6.2
 packaging==20.4


### PR DESCRIPTION
## Description

Our jobs were blocking each other. Since version 13 Python Telegram bot uses external library for jobs and the problem doesn't occur anymore.
see [changelog](https://github.com/python-telegram-bot/python-telegram-bot/wiki/Transition-guide-to-Version-13.0) 
## Fixes (issue)
Dispatched jobs don't run in the defined interval.
## Improvements
Increased number of workers from 4 to 8 and added #139 regarding that (to be discussed)

After version bump after some jobs the line 
`venv/lib/python3.8/site-packages/telegram/ext/dispatcher.py:563` throws and I couldn't find the reason and consequences. To avoid undefined behavior and error logs in the logs I disabled persistence of bot_data as it is not really necessary - the data stored there can be defined as "cache". 
It may be a library bug connected with the changes of persistence implementation described in [changelog](https://github.com/python-telegram-bot/python-telegram-bot/wiki/Transition-guide-to-Version-13.0). I didn't want to spend more time on it as the problem looks really tricky.

## How Has This Been Tested?
Unit tests were run
Manually clicked through UI on chaosnet and testnet

## Checklist:
If you have any comments regarding one of these points just write it down.

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
